### PR TITLE
fix: 修复编译警告和布产表导入图片显示问题，添加物料颜色选项

### DIFF
--- a/buluerp_vue/ruoyi-admin/pom.xml
+++ b/buluerp_vue/ruoyi-admin/pom.xml
@@ -39,8 +39,9 @@
 
          <!-- Mysql驱动包 -->
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.0.33</version>
         </dependency>
 
         <!-- 核心模块-->

--- a/buluerp_vue/ruoyi-admin/src/main/java/com/ruoyi/web/domain/ErpMaterialInfo.java
+++ b/buluerp_vue/ruoyi-admin/src/main/java/com/ruoyi/web/domain/ErpMaterialInfo.java
@@ -95,6 +95,11 @@ public class ErpMaterialInfo extends BaseEntity {
     @Example("-")
     private String spareCode;
 
+    @Excel(name = "颜色编号")
+    @Example("红,蓝,绿")
+    @ApiModelProperty(value = "颜色编号 [list|POST|PUT|response]")
+    private String colorCode;
+
     /** 3D模型文件URL（GLTF格式） */
     private String modelUrl;
 
@@ -243,6 +248,14 @@ public class ErpMaterialInfo extends BaseEntity {
 
     public void setSpareCode(String spareCode) {
         this.spareCode = spareCode;
+    }
+
+    public String getColorCode() {
+        return colorCode;
+    }
+
+    public void setColorCode(String colorCode) {
+        this.colorCode = colorCode;
     }
 
     public MultipartFile getDrawingReferenceFile() {

--- a/buluerp_vue/ruoyi-admin/src/main/java/com/ruoyi/web/service/impl/ErpProductionScheduleServiceImpl.java
+++ b/buluerp_vue/ruoyi-admin/src/main/java/com/ruoyi/web/service/impl/ErpProductionScheduleServiceImpl.java
@@ -134,9 +134,8 @@ public class ErpProductionScheduleServiceImpl
         if (erpProductionSchedule.getPicture() != null) {
             String url = FileUploadUtils.upload(erpProductionSchedule.getPicture());
             erpProductionSchedule.setPictureUrl(url);
-        } else {
-            erpProductionSchedule.setPictureUrl(null);
         }
+        // 注意：Excel导入时picture为null但pictureUrl已由ExcelUtil设置，不应覆盖为null
         erpProductionSchedule.setOperator(SecurityUtils.getUsername());
         erpProductionSchedule.setCreationTime(DateUtils.getNowDate());
         if (0 == getBaseMapper().insert(erpProductionSchedule)) {
@@ -472,9 +471,8 @@ public class ErpProductionScheduleServiceImpl
         if (erpProductionSchedule.getPicture() != null) {
             String url = FileUploadUtils.upload(erpProductionSchedule.getPicture());
             erpProductionSchedule.setPictureUrl(url);
-        } else {
-            erpProductionSchedule.setPictureUrl(null);
         }
+        // 未上传新图片时保留原图片，不覆盖为null
         erpProductionSchedule.setOperator(SecurityUtils.getUsername());
         if (0 == getBaseMapper().updateById(erpProductionSchedule)) {
             throw new ServiceException("操作失败");

--- a/buluerp_vue/ruoyi-admin/src/main/java/com/ruoyi/web/service/impl/ListValidationServiceImpl.java
+++ b/buluerp_vue/ruoyi-admin/src/main/java/com/ruoyi/web/service/impl/ListValidationServiceImpl.java
@@ -22,6 +22,7 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -201,8 +202,14 @@ public class ListValidationServiceImpl implements IListValidationService {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T createExample(Class<T> clazz) throws InstantiationException, IllegalAccessException {
-        T example = clazz.newInstance();
+        T example;
+        try {
+            example = clazz.getDeclaredConstructor().newInstance();
+        } catch (NoSuchMethodException | InvocationTargetException e) {
+            throw new InstantiationException("无法实例化类 " + clazz.getName() + ": " + e.getMessage());
+        }
         List<Field> fields = new ArrayList<>();
         Class<?> superClass = clazz;
         while (superClass != null) {
@@ -229,7 +236,11 @@ public class ListValidationServiceImpl implements IListValidationService {
                         } else if (type == Set.class) {
                             list = new HashSet<>();
                         } else if (!type.isInterface()) {
-                            list = (Collection<Object>) type.newInstance();
+                            try {
+                                list = (Collection<Object>) type.getDeclaredConstructor().newInstance();
+                            } catch (NoSuchMethodException | InvocationTargetException e) {
+                                throw new UnsupportedExampleTypeException("无法实例化集合类型 " + type.getName() + ": " + e.getMessage());
+                            }
                         } else {
                             throw new UnsupportedExampleTypeException("不支持的集合类型");
                         }

--- a/buluerp_vue/ruoyi-admin/src/main/resources/mapper/web/ErpMaterialInfoMapper.xml
+++ b/buluerp_vue/ruoyi-admin/src/main/resources/mapper/web/ErpMaterialInfoMapper.xml
@@ -18,6 +18,7 @@
         <result property="sampleLocation" column="sample_location" />
         <result property="remarks" column="remarks" />
         <result property="spareCode" column="spare_code" />
+        <result property="colorCode" column="color_code" />
         <result property="purchased" column="purchased" />
         <result property="modelUrl" column="model_url" />
     </resultMap>
@@ -39,6 +40,7 @@
             m.sample_location,
             m.remarks,
             m.spare_code,
+            m.color_code,
             m.model_url,
             (case when p.id is not null then 1 else 0 end) as purchased
         from erp_material_info m
@@ -93,6 +95,9 @@
             <if test="spareCode != null">
                 spare_code,
             </if>
+            <if test="colorCode != null">
+                color_code,
+            </if>
             <if test="modelUrl != null">
                 model_url,
             </if>
@@ -144,6 +149,9 @@
             <if test="spareCode != null">
                 #{spareCode},
             </if>
+            <if test="colorCode != null">
+                #{colorCode},
+            </if>
             <if test="modelUrl != null">
                 #{modelUrl},
             </if>
@@ -193,6 +201,9 @@
             </if>
             <if test="spareCode != null">
                 spare_code = #{spareCode},
+            </if>
+            <if test="colorCode != null">
+                color_code = #{colorCode},
             </if>
             <if test="modelUrl != null">
                 model_url = #{modelUrl},
@@ -265,6 +276,9 @@
             </if>
             <if test="spareCode != null and spareCode != ''">
                 and m.spare_code like concat('%', #{spareCode}, '%')
+            </if>
+            <if test="colorCode != null and colorCode != ''">
+                and m.color_code like concat('%', #{colorCode}, '%')
             </if>
             <if test="purchased != null">
                 <choose>

--- a/buluerp_vue/ruoyi-common/src/main/java/com/ruoyi/common/utils/poi/ExcelUtil.java
+++ b/buluerp_vue/ruoyi-common/src/main/java/com/ruoyi/common/utils/poi/ExcelUtil.java
@@ -441,7 +441,7 @@ public class ExcelUtil<T>
                     Object val = this.getCellValue(row, entry.getKey());
 
                     // 如果不存在实例则新建.
-                    entity = (entity == null ? clazz.newInstance() : entity);
+                    entity = (entity == null ? clazz.getDeclaredConstructor().newInstance() : entity);
                     // 从map中得到对应列的field.
                     Field field = (Field) entry.getValue()[0];
                     Excel attr = (Excel) entry.getValue()[1];
@@ -2116,7 +2116,7 @@ public class ExcelUtil<T>
      * @return 提取的实体类对象
      */
     public static <Type> Type extractEntityFromSheet(Sheet sheet, Class<Type> clazz, int startRow, int endRow) throws Exception {
-        Type entity = clazz.newInstance();
+        Type entity = clazz.getDeclaredConstructor().newInstance();
         List<Cell> cells = getNonMergedCells(sheet, startRow, endRow);
         Map<String, Field> fieldMap = getExcelNameToFieldMap(clazz);
 

--- a/buluerp_vue/ruoyi-ui/.gitignore
+++ b/buluerp_vue/ruoyi-ui/.gitignore
@@ -21,3 +21,4 @@ selenium-debug.log
 
 package-lock.json
 yarn.lock
+pnpm-workspace.yaml

--- a/buluerp_vue/sql/20260721_add_material_color_code.sql
+++ b/buluerp_vue/sql/20260721_add_material_color_code.sql
@@ -1,0 +1,3 @@
+ALTER TABLE erp_material_info
+    ADD COLUMN color_code VARCHAR(255) NULL COMMENT '颜色编号'
+    AFTER spare_code;


### PR DESCRIPTION
- 修复 clazz.newInstance() 废弃API (ListValidationServiceImpl, ExcelUtil)
- 修复 MySQL连接器迁移警告 (mysql-connector-java -> mysql-connector-j)
- 修复布产表Excel导入后图片URL被覆盖为null的问题 (ErpProductionScheduleServiceImpl)
- 新增 ErpMaterialInfo 颜色编号(colorCode)字段
- 添加数据库迁移脚本 sql/20260721_add_material_color_code.sql
- 添加 pnpm-workspace.yaml 到 .gitignore